### PR TITLE
Mouse down event required to place a new range.

### DIFF
--- a/dev/modules/bar.js
+++ b/dev/modules/bar.js
@@ -43,6 +43,7 @@ class Bar extends Base {
 
     this.rangeIdCount = 0;
     this.rangeList = [];
+    this.clicked=false;
 
     this.emitter = new Emitter;
   }
@@ -126,16 +127,19 @@ class Bar extends Base {
   }
 
   mousedown(event) {
+    this.clicked=true;
   }
 
   mouseup(event) {
-    if (this.ghost) {
-      this.add([this.ghost.left, this.ghost.right])
+    if (this.ghost && this.clicked) {
+      this.add([this.ghost.left, this.ghost.right]);
+      this.clicked=false
     }
   }
 
   mouseleave(event) {
     this.removeGhost();
+    this.clicked=false;
   }
 
   getInsideRange(cursor) {
@@ -202,6 +206,7 @@ class Bar extends Base {
     if (left < this.options.min) {
       return null
     }
+
     if (this.options.max < right) {
       return null
     }

--- a/dist/multirangeslider.js
+++ b/dist/multirangeslider.js
@@ -337,6 +337,7 @@ var Bar = (function (_Base) {
 
     this.rangeIdCount = 0;
     this.rangeList = [];
+    this.clicked = false;
 
     this.emitter = new _emitter2['default']();
   }
@@ -432,18 +433,22 @@ var Bar = (function (_Base) {
     }
   }, {
     key: 'mousedown',
-    value: function mousedown(event) {}
+    value: function mousedown(event) {
+      this.clicked = true;
+    }
   }, {
     key: 'mouseup',
     value: function mouseup(event) {
-      if (this.ghost) {
+      if (this.ghost && this.clicked) {
         this.add([this.ghost.left, this.ghost.right]);
+        this.clicked = false;
       }
     }
   }, {
     key: 'mouseleave',
     value: function mouseleave(event) {
       this.removeGhost();
+      this.clicked = false;
     }
   }, {
     key: 'getInsideRange',
@@ -557,6 +562,7 @@ var Bar = (function (_Base) {
       if (left < this.options.min) {
         return null;
       }
+
       if (this.options.max < right) {
         return null;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -449,6 +449,7 @@ QUnit.module("multirangeslider", function (hooks) {
 
     QUnit.test("click", function (assert) {
       move(this.bar_el, {startX: 0});
+      down(this.bar_el);
       up(this.bar_el);
       assert.equal(this.target.querySelectorAll('.multirangeslider-range').length, 2,
         'element should attach to dom');


### PR DESCRIPTION
Hello,

I'm using multiple "multiple-range sliders" next to each other in one of my project, that i'm currently trying to migrate from Elessar to your implementation.

I noticed a small issue : when dragging the mouse to define a range on one bar, if the mouse up event ends up occuring on another bar, it'll add a new range on this other bar.

As you can see : 

![](https://thumbs.gfycat.com/ShimmeringPaltryAfricanbushviper-size_restricted.gif)

I modified it so an explicit mouse down event on the bar is required before being actually able to place a new range now : 

![](https://thumbs.gfycat.com/GenuineNimbleAmericanbobtail-size_restricted.gif)